### PR TITLE
Return early when no entity mappings are set

### DIFF
--- a/src/User/Infra/Doctrine/SqlEmailLookup.php
+++ b/src/User/Infra/Doctrine/SqlEmailLookup.php
@@ -28,11 +28,19 @@ final class SqlEmailLookup implements EmailLookupInterface
 
     public function exists(string $email): bool
     {
+        if (!$this->entityFieldMapping) {
+            return false;
+        }
+
         return (bool) $this->createQuery($this->entityFieldMapping, $email)->getScalarResult();
     }
 
     public function existsPrimary(string $email): bool
     {
+        if (!$this->primaryEntityFieldMapping) {
+            return false;
+        }
+
         return (bool) $this->createQuery($this->primaryEntityFieldMapping, $email)->getScalarResult();
     }
 


### PR DESCRIPTION
Use-case: Fresh Symfony project install and running `composer require`