### PR TITLE
Add src/ as a filter target for PHPUnit code coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,4 +19,10 @@
             <directory>./src/*/Tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Fixes `Error:  Incorrect whitelist config, no code coverage will be generated.` when running PHPUnit with code coverage