### PR TITLE
simplify jwt user provider

### DIFF
--- a/src/User/Infra/Security/Jwt/SecurityUserProvider.php
+++ b/src/User/Infra/Security/Jwt/SecurityUserProvider.php
@@ -8,9 +8,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Security\User\UserProviderWithPayloadSu
 use MsgPhp\Domain\Exception\EntityNotFoundException;
 use MsgPhp\Domain\Factory\EntityAwareFactoryInterface;
 use MsgPhp\User\Entity\User;
-use MsgPhp\User\Infra\Security\SecurityUser;
 use MsgPhp\User\Infra\Security\SecurityUserProvider as BaseSecurityUserProvider;
-use MsgPhp\User\Infra\Security\UserRolesProviderInterface;
 use MsgPhp\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -23,14 +21,12 @@ final class SecurityUserProvider implements UserProviderWithPayloadSupportsInter
     private $provider;
     private $repository;
     private $factory;
-    private $roleProvider;
 
-    public function __construct(BaseSecurityUserProvider $provider, UserRepositoryInterface $repository, EntityAwareFactoryInterface $factory, UserRolesProviderInterface $roleProvider = null)
+    public function __construct(BaseSecurityUserProvider $provider, UserRepositoryInterface $repository, EntityAwareFactoryInterface $factory)
     {
         $this->provider = $provider;
         $this->repository = $repository;
         $this->factory = $factory;
-        $this->roleProvider = $roleProvider;
     }
 
     public function loadUserByUsernameAndPayload($username, array $payload): UserInterface
@@ -41,7 +37,7 @@ final class SecurityUserProvider implements UserProviderWithPayloadSupportsInter
             throw new UsernameNotFoundException($e->getMessage());
         }
 
-        return $this->fromUser($user);
+        return $this->provider->fromUser($user);
     }
 
     public function loadUserByUsername($username): UserInterface
@@ -57,10 +53,5 @@ final class SecurityUserProvider implements UserProviderWithPayloadSupportsInter
     public function supportsClass($class): bool
     {
         return $this->provider->supportsClass($class);
-    }
-
-    private function fromUser(User $user): SecurityUser
-    {
-        return new SecurityUser($user, $this->roleProvider ? $this->roleProvider->getRoles($user) : []);
     }
 }

--- a/src/User/Infra/Security/SecurityUserProvider.php
+++ b/src/User/Infra/Security/SecurityUserProvider.php
@@ -20,13 +20,13 @@ final class SecurityUserProvider implements UserProviderInterface
 {
     private $repository;
     private $factory;
-    private $roleProvider;
+    private $rolesProvider;
 
-    public function __construct(UserRepositoryInterface $repository, EntityAwareFactoryInterface $factory, UserRolesProviderInterface $roleProvider = null)
+    public function __construct(UserRepositoryInterface $repository, EntityAwareFactoryInterface $factory, UserRolesProviderInterface $rolesProvider = null)
     {
         $this->repository = $repository;
         $this->factory = $factory;
-        $this->roleProvider = $roleProvider;
+        $this->rolesProvider = $rolesProvider;
     }
 
     public function loadUserByUsername($username): UserInterface
@@ -43,7 +43,7 @@ final class SecurityUserProvider implements UserProviderInterface
     public function refreshUser(UserInterface $user): UserInterface
     {
         if (!$user instanceof SecurityUser) {
-            throw new UnsupportedUserException(sprintf('Unsupported user "%s"', get_class($user)));
+            throw new UnsupportedUserException(sprintf('Unsupported user "%s".', get_class($user)));
         }
 
         try {
@@ -60,8 +60,8 @@ final class SecurityUserProvider implements UserProviderInterface
         return SecurityUser::class === $class;
     }
 
-    private function fromUser(User $user): SecurityUser
+    public function fromUser(User $user): SecurityUser
     {
-        return new SecurityUser($user, $this->roleProvider ? $this->roleProvider->getRoles($user) : []);
+        return new SecurityUser($user, $this->rolesProvider ? $this->rolesProvider->getRoles($user) : []);
     }
 }


### PR DESCRIPTION
it's weird we rely on decorated provider to check for supported security user, but then initialize it with hard coupling (assuming the supported user).

exposing `fromUser` from the base provider fixes it.

cc @DevMDamien 
