### PR TITLE
Add missing pieces to make:user

### DIFF
--- a/bin/create-project
+++ b/bin/create-project
@@ -6,8 +6,8 @@ if [[ $# -gt 1 ]] ; then
 fi
 
 DIR="${1:-var/test-project/}"
-PACKAGES="symfony/var-dumper "
-DEV_PACKAGES="maker server "
+PACKAGES="orm "
+DEV_PACKAGES="debug maker server "
 
 for PACKAGE in $(find src/*Bundle/composer.json -type f) ; do
     PACKAGE_NAME=$(grep -E "^\s*\"name\"\s*:\s*\"msgphp\/([^\"]+)\"\s*,\s*$" "${PACKAGE}")

--- a/bin/create-project
+++ b/bin/create-project
@@ -7,6 +7,7 @@ fi
 
 DIR="${1:-var/test-project/}"
 PACKAGES="symfony/var-dumper "
+DEV_PACKAGES="maker server "
 
 for PACKAGE in $(find src/*Bundle/composer.json -type f) ; do
     PACKAGE_NAME=$(grep -E "^\s*\"name\"\s*:\s*\"msgphp\/([^\"]+)\"\s*,\s*$" "${PACKAGE}")
@@ -27,7 +28,8 @@ pushd "${DIR}" &> /dev/null
 
 echo -e "\e[34mInstalling dependencies...\e[0m"
 composer config extra.symfony.allow-contrib true && \
-composer require --prefer-dist --no-suggest ${PACKAGES}
+composer require --prefer-dist --no-suggest ${PACKAGES} && \
+composer require --prefer-dist --dev --no-suggest ${DEV_PACKAGES}
 [[ $? -ne 0 ]] && exit 1
 
 popd &> /dev/null

--- a/src/Domain/Infra/Console/Context/ClassContextFactory.php
+++ b/src/Domain/Infra/Console/Context/ClassContextFactory.php
@@ -145,18 +145,17 @@ final class ClassContextFactory implements ContextFactoryInterface
                 continue;
             }
 
-            if ($element->generate($io, $generated)) {
-                $this->generatedValues[] = [$element->label, json_encode($generated)];
-                $context[$key] = $element->normalize($generated);
-                continue;
-            }
-
-            if ($required) {
+            if ($required || $given) {
                 if (!$interactive) {
                     throw new \LogicException(sprintf('No value provided for "%s".', $field));
                 }
 
-                $context[$key] = $this->askRequiredValue($io, $element, $value);
+                if ($element->generate($io, $generated)) {
+                    $this->generatedValues[] = [$element->label, json_encode($generated)];
+                    $context[$key] = $element->normalize($generated);
+                } else {
+                    $context[$key] = $this->askRequiredValue($io, $element, $value);
+                }
                 continue;
             }
 

--- a/src/UserBundle/Maker/UserMaker.php
+++ b/src/UserBundle/Maker/UserMaker.php
@@ -282,13 +282,13 @@ PHP
                     $traitUseLine += 4;
                 }
             }
+        }
 
-            if (!isset($traits[Entity\Features\ResettablePassword::class]) && $this->hasPassword() && $io->confirm('Can users reset their password?')) {
-                $this->passwordReset = true;
-                $addUses[Entity\Features\ResettablePassword::class] = true;
-                $addTraitUses['ResettablePassword'] = true;
-                $enableEventHandler();
-            }
+        $this->passwordReset = isset($traits[Entity\Features\ResettablePassword::class]);
+        if (!$this->passwordReset && $this->hasPassword() && $io->confirm('Can users reset their password?')) {
+            $addUses[Entity\Features\ResettablePassword::class] = true;
+            $addTraitUses['ResettablePassword'] = true;
+            $enableEventHandler();
         }
 
         if (!isset($this->classMapping[Entity\Role::class]) && $io->confirm('Enable user roles?')) {

--- a/src/UserBundle/Maker/UserMaker.php
+++ b/src/UserBundle/Maker/UserMaker.php
@@ -113,6 +113,7 @@ final class UserMaker implements MakerInterface
         }
 
         $io->success('Done!');
+        $io->note('Don\'t forget to update your database schema, if needed.');
     }
 
     private function generateUser(ConsoleStyle $io): void
@@ -521,9 +522,10 @@ PHP;
             'credentialShortClass' => self::splitClass($this->credential)[1],
         ])];
         $this->services[] = <<<PHP
-->set(${contextElementFactoryClass}::class)
+// non-FQCN service for decorating
+->set('app.console.class_context_element_factory', ${contextElementFactoryClass}::class)
     ->decorate(MsgPhp\\Domain\\Infra\\Console\\Context\\ClassContextElementFactoryInterface::class)
-    ->arg('\$factory', ref(${contextElementFactoryClass}::class.'.inner'))
+    ->arg('\$factory', ref('app.console.class_context_element_factory.inner'))
 PHP;
     }
 

--- a/src/UserBundle/Maker/UserMaker.php
+++ b/src/UserBundle/Maker/UserMaker.php
@@ -84,7 +84,6 @@ final class UserMaker implements MakerInterface
             while (file_exists($configFile)) {
                 $configFile = $this->projectDir.'/config/packages/msgphp_user.make_'.++$i.'.php';
             }
-
             array_unshift($this->writes, [$configFile, self::getSkeleton('config.php', [
                 'config' => $this->configs ? var_export(array_merge_recursive(...$this->configs), true) : null,
                 'services' => $this->services,

--- a/src/UserBundle/Maker/UserMaker.php
+++ b/src/UserBundle/Maker/UserMaker.php
@@ -75,14 +75,20 @@ final class UserMaker implements MakerInterface
         $this->user = new \ReflectionClass($this->classMapping[Entity\User::class]);
 
         $this->generateUser($io);
-        //$this->generateControllers($io);
+        $this->generateControllers($io);
         $this->generateConsole($io);
 
         if ($this->configs || $this->services) {
-            $this->writes[] = [$this->projectDir.'/config/packages/msgphp_user.make.php', self::getSkeleton('config.php', [
+            $configFile = $this->projectDir.'/config/packages/msgphp_user.make.php';
+            $i = 0;
+            while (file_exists($configFile)) {
+                $configFile = $this->projectDir.'/config/packages/msgphp_user.make_'.++$i.'.php';
+            }
+
+            array_unshift($this->writes, [$configFile, self::getSkeleton('config.php', [
                 'config' => $this->configs ? var_export(array_merge_recursive(...$this->configs), true) : null,
                 'services' => $this->services,
-            ])];
+            ])]);
             $this->configs = $this->services = [];
         }
 
@@ -317,7 +323,7 @@ PHP
             ])];
             $this->services[] = <<<PHP
 ->set(${rolesProviderClass}::class)
-->alias(MsgPhp\User\Infra\Security\UserRolesProviderInterface::class, ${rolesProviderClass}::class)
+->alias(MsgPhp\\User\\Infra\\Security\\UserRolesProviderInterface::class, ${rolesProviderClass}::class)
 PHP;
         }
 
@@ -517,7 +523,7 @@ PHP;
         ])];
         $this->services[] = <<<PHP
 ->set(${contextElementFactoryClass}::class)
-    ->decorate(MsgPhp\Domain\Infra\Console\Context\ClassContextElementFactoryInterface::class)
+    ->decorate(MsgPhp\\Domain\\Infra\\Console\\Context\\ClassContextElementFactoryInterface::class)
     ->arg('\$factory', ref(${contextElementFactoryClass}::class.'.inner'))
 PHP;
     }

--- a/src/UserBundle/Resources/skeleton/config.php
+++ b/src/UserBundle/Resources/skeleton/config.php
@@ -36,8 +36,8 @@ PHP;
 return <<<PHP
 <?php
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref; 
+use Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ContainerConfigurator;
+use function Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ref;
 
 return function (ContainerConfigurator \$container) {
 ${extensionConfig}${serviceConfig}

--- a/src/UserBundle/Resources/skeleton/config.php
+++ b/src/UserBundle/Resources/skeleton/config.php
@@ -2,26 +2,33 @@
 
 declare(strict_types=1);
 
-$serviceConfig = '';
-if ($services) {
-    $services = implode("\n", array_map(function ($class, string $alias): string {
-        $service = '        ->set('.(is_string($class) ? $class : $alias).'::class)';
-        if (is_string($class)) {
-            $service .= "\n        ->alias(${alias}::class, ${class}::class)";
-        }
+$extensionConfig = $serviceConfig = $sep = '';
 
-        return $service;
-    }, array_keys($services), $services));
+if ($config) {
+    $extensionConfig = <<<PHP
+    \$container->extension('msgphp_user', ${config});
+PHP;
+
+}
+
+foreach ($services as $service) {
+    $serviceConfig .= $sep.'        '.str_replace("\n", "\n        ", $service);
+    $sep = "\n\n";
+}
+
+if ($serviceConfig) {
+    if ($extensionConfig) {
+        $extensionConfig .= "\n\n";
+    }
+
     $serviceConfig = <<<PHP
-
-
     \$container->services()
         ->defaults()
             ->private()
             ->autoconfigure()
             ->autowire()
 
-${services}
+${serviceConfig}
     ;
 PHP;
 }
@@ -30,9 +37,10 @@ return <<<PHP
 <?php
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\ref; 
 
 return function (ContainerConfigurator \$container) {
-    \$container->extension('msgphp_user', ${config});${serviceConfig}
+${extensionConfig}${serviceConfig}
 };
 
 PHP;

--- a/src/UserBundle/Resources/skeleton/config.php
+++ b/src/UserBundle/Resources/skeleton/config.php
@@ -2,33 +2,31 @@
 
 declare(strict_types=1);
 
-$extensionConfig = $serviceConfig = $sep = '';
+$extensionConfig = $servicesConfig = $sep = '';
 
 if ($config) {
     $extensionConfig = <<<PHP
     \$container->extension('msgphp_user', ${config});
 PHP;
-
 }
 
 foreach ($services as $service) {
-    $serviceConfig .= $sep.'        '.str_replace("\n", "\n        ", $service);
+    $servicesConfig .= $sep.'        '.str_replace("\n", "\n        ", $service);
     $sep = "\n\n";
 }
 
-if ($serviceConfig) {
+if ($servicesConfig) {
     if ($extensionConfig) {
         $extensionConfig .= "\n\n";
     }
-
-    $serviceConfig = <<<PHP
+    $servicesConfig = <<<PHP
     \$container->services()
         ->defaults()
             ->private()
             ->autoconfigure()
             ->autowire()
 
-${serviceConfig}
+${servicesConfig}
     ;
 PHP;
 }
@@ -40,7 +38,7 @@ use Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ContainerConf
 use function Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ref;
 
 return function (ContainerConfigurator \$container) {
-${extensionConfig}${serviceConfig}
+${extensionConfig}${servicesConfig}
 };
 
 PHP;

--- a/src/UserBundle/Resources/skeleton/service/ClassContextElementFactory.php
+++ b/src/UserBundle/Resources/skeleton/service/ClassContextElementFactory.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+$uses = [
+    'use '.$userClass.';',
+    'use '.$credentialClass.';',
+    'use MsgPhp\Domain\Infra\Console\Context\ClassContextElementFactoryInterface;',
+    'use MsgPhp\Domain\Infra\Console\Context\ContextElement;',
+];
+$cases = [];
+
+if (false !== strpos($credentialClass, 'Email')) {
+    $cases[] = <<<PHP
+            case 'email':
+                \$element->label = 'E-mail';
+                break;
+PHP;
+}
+
+if (false !== strpos($credentialClass, 'Password')) {
+    $uses[] = 'use MsgPhp\User\Password\PasswordHashingInterface;';
+    $constructor = <<<PHP
+    private \$factory;
+    private \$passwordHashing;
+
+    public function __construct(ClassContextElementFactoryInterface \$factory, PasswordHashingInterface \$passwordHashing)
+    {
+        \$this->factory = \$factory;
+        \$this->passwordHashing = \$passwordHashing;
+    }
+PHP;
+    $cases[] = <<<PHP
+            case 'password':
+                if (${userShortClass}::class === \$class || ${credentialShortClass}::class === \$class) {
+                    \$element
+                        ->hide()
+                        ->generator(function (): string {
+                            return bin2hex(random_bytes(8));
+                        })
+                        ->normalizer(function (string \$value): string {
+                            return \$this->passwordHashing->hash(\$value);
+                        });
+                }
+                break;
+PHP;
+} else {
+    $constructor = <<<PHP
+    private \$factory;
+
+    public function __construct(ClassContextElementFactoryInterface \$factory)
+    {
+        \$this->factory = \$factory;
+    }
+PHP;
+}
+
+$switch = '';
+if ($cases) {
+    $switch = "\n\n        switch (\$argument) {\n".implode("\n", $cases)."\n        }";
+}
+
+sort($uses);
+$uses = implode("\n", $uses);
+
+return <<<PHP
+<?php
+
+declare(strict_types=1);
+
+namespace ${ns};
+
+${uses}
+
+final class ${class} implements ClassContextElementFactoryInterface
+{
+${constructor}
+
+    public function getElement(string \$class, string \$method, string \$argument): ContextElement
+    {
+        \$element = \$this->factory->getElement(\$class, \$method, \$argument);${switch}
+
+        return \$element;
+    }
+}
+
+PHP;

--- a/src/UserBundle/Resources/skeleton/service/ClassContextElementFactory.php
+++ b/src/UserBundle/Resources/skeleton/service/ClassContextElementFactory.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 $uses = [
     'use '.$userClass.';',
     'use '.$credentialClass.';',
-    'use MsgPhp\Domain\Infra\Console\Context\ClassContextElementFactoryInterface;',
-    'use MsgPhp\Domain\Infra\Console\Context\ContextElement;',
+    'use MsgPhp\\Domain\\Infra\\Console\\Context\\ClassContextElementFactoryInterface;',
+    'use MsgPhp\\Domain\\Infra\\Console\\Context\\ContextElement;',
 ];
 $cases = [];
 

--- a/src/UserBundle/Resources/skeleton/service/UserRolesProvider.php
+++ b/src/UserBundle/Resources/skeleton/service/UserRolesProvider.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 $uses = [
     'use '.$userClass.';',
     'use '.$userRoleClass.';',
-    'use MsgPhp\User\Entity\User as BaseUser;',
-    'use MsgPhp\User\Infra\Security\UserRolesProviderInterface;',
+    'use MsgPhp\\User\\Entity\\User as BaseUser;',
+    'use MsgPhp\\User\\Infra\\Security\\UserRolesProviderInterface;',
 ];
 
 sort($uses);


### PR DESCRIPTION
still not sure about `make:user` chaning doctrine annotations. I'm considering to go with `@ORM\GgeneratedValue` by default, from the recipe. Also given the default type is integer, and then remove it if you go UUID or so.

Thus a doc issue mostly.

Fixes #133 

ref https://github.com/symfony/recipes-contrib/pull/342