### PR TITLE
require password salt upfront

### DIFF
--- a/src/User/Entity/Credential/EmailSaltedPassword.php
+++ b/src/User/Entity/Credential/EmailSaltedPassword.php
@@ -19,11 +19,11 @@ final class EmailSaltedPassword implements CredentialInterface, PasswordProtecte
     use EmailAsUsername;
     use PasswordWithSaltProtected;
 
-    public function __construct(string $email, string $password, string $passwordSalt = null)
+    public function __construct(string $email, string $password, string $passwordSalt)
     {
         $this->email = $email;
         $this->password = $password;
-        $this->passwordSalt = $passwordSalt ?? bin2hex(random_bytes(32));
+        $this->passwordSalt = $passwordSalt;
     }
 
     public function withEmail(string $email): self

--- a/src/User/Entity/Credential/NicknameSaltedPassword.php
+++ b/src/User/Entity/Credential/NicknameSaltedPassword.php
@@ -19,11 +19,11 @@ final class NicknameSaltedPassword implements CredentialInterface, PasswordProte
     use NicknameAsUsername;
     use PasswordWithSaltProtected;
 
-    public function __construct(string $nickname, string $password, string $passwordSalt = null)
+    public function __construct(string $nickname, string $password, string $passwordSalt)
     {
         $this->nickname = $nickname;
         $this->password = $password;
-        $this->passwordSalt = $passwordSalt ?? bin2hex(random_bytes(32));
+        $this->passwordSalt = $passwordSalt;
     }
 
     public function withNickname(string $nickname): self

--- a/src/UserBundle/Maker/UserMaker.php
+++ b/src/UserBundle/Maker/UserMaker.php
@@ -228,7 +228,7 @@ final class UserMaker implements MakerInterface
         if (!$this->hasUsername() && $io->confirm('Generate a user credential?')) {
             $credentials = [];
             foreach (glob(Configuration::getPackageDir().'/Entity/Credential/*.php') as $file) {
-                if ('Anonymous' === $credential = basename($file, '.php')) {
+                if ('Anonymous' === ($credential = basename($file, '.php')) || false !== strpos($credential, 'SaltedPassword')) {
                     continue;
                 }
                 $credentials[] = $credential;


### PR DESCRIPTION
fixes #157

generating default salts was a bad idea, the password value is hashed thus implies we already know the salt.

next is to handle this with the hashed password form type during make:user, as well as providing it from the CLI class context during user:register