### PR TITLE
tweak attribute value checksum

### DIFF
--- a/UPGRADE-0.6.md
+++ b/UPGRADE-0.6.md
@@ -2,4 +2,5 @@
 
 ## Eav
 
-- Removed `AttributeValue::getChecksum()`
+- Marked `AttributeValue::getChecksum()` static, requiring `$value` as 1st argument
+- Finalized `AttributeValue::get/changeValue()`

--- a/UPGRADE-0.6.md
+++ b/UPGRADE-0.6.md
@@ -1,0 +1,5 @@
+# UPGRADE FROM 0.5 to 0.6
+
+## Eav
+
+- Removed `AttributeValue::getChecksum()`

--- a/src/Eav/Entity/AttributeValue.php
+++ b/src/Eav/Entity/AttributeValue.php
@@ -21,9 +21,9 @@ abstract class AttributeValue
     private $value;
     private $isNull;
 
-    public static function getChecksum($value, string $type = null): string
+    public static function getChecksum($value): string
     {
-        return md5(serialize([$type ?? gettype($value), $value]));
+        return md5(serialize([\gettype($value), static::prepareChecksumValue($value)]));
     }
 
     public function __construct(Attribute $attribute, $value)
@@ -73,6 +73,11 @@ abstract class AttributeValue
 
         $this->value = $value;
         $this->checksum = static::getChecksum($value);
+    }
+
+    protected static function prepareChecksumValue($value)
+    {
+        return $value;
     }
 
     protected function doClearValue(): void

--- a/src/Eav/Entity/AttributeValue.php
+++ b/src/Eav/Entity/AttributeValue.php
@@ -21,9 +21,9 @@ abstract class AttributeValue
     private $value;
     private $isNull;
 
-    public static function getChecksum($value): string
+    public static function getChecksum($value, string $type = null): string
     {
-        return md5(serialize($value));
+        return md5(serialize([$type ?? gettype($value), $value]));
     }
 
     public function __construct(Attribute $attribute, $value)

--- a/src/Eav/Entity/AttributeValue.php
+++ b/src/Eav/Entity/AttributeValue.php
@@ -53,11 +53,6 @@ abstract class AttributeValue
         return $this->value = $value;
     }
 
-    public function getChecksum(): string
-    {
-        return $this->checksum;
-    }
-
     public function changeValue($value): void
     {
         $this->isNull = true;
@@ -69,7 +64,12 @@ abstract class AttributeValue
             $this->value = $value;
         }
 
-        $this->checksum = md5(serialize($value));
+        $this->checksum = static::createChecksumForValue($value);
+    }
+
+    protected static function createChecksumForValue($value): string
+    {
+        return md5(serialize($value));
     }
 
     protected function doSetValue($value): void

--- a/src/Eav/Entity/AttributeValue.php
+++ b/src/Eav/Entity/AttributeValue.php
@@ -21,6 +21,11 @@ abstract class AttributeValue
     private $value;
     private $isNull;
 
+    public static function getChecksum($value): string
+    {
+        return md5(serialize($value));
+    }
+
     public function __construct(Attribute $attribute, $value)
     {
         $this->attribute = $attribute;
@@ -40,9 +45,13 @@ abstract class AttributeValue
         return $this->attribute->getId();
     }
 
-    public function getValue()
+    final public function getValue()
     {
-        if ($this->isNull || null !== $this->value) {
+        if ($this->isNull) {
+            return null;
+        }
+
+        if (null !== $this->value) {
             return $this->value;
         }
 
@@ -53,23 +62,22 @@ abstract class AttributeValue
         return $this->value = $value;
     }
 
-    public function changeValue($value): void
+    final public function changeValue($value): void
     {
-        $this->isNull = true;
-        $this->boolValue = $this->intValue = $this->floatValue = $this->stringValue = $this->dateTimeValue = $this->value = null;
+        $this->doClearValue();
+        $this->isNull = null === $value;
 
-        if (null !== $value) {
+        if (!$this->isNull) {
             $this->doSetValue($value);
-
-            $this->value = $value;
         }
 
-        $this->checksum = static::createChecksumForValue($value);
+        $this->value = $value;
+        $this->checksum = static::getChecksum($value);
     }
 
-    protected static function createChecksumForValue($value): string
+    protected function doClearValue(): void
     {
-        return md5(serialize($value));
+        $this->boolValue = $this->intValue = $this->floatValue = $this->stringValue = $this->dateTimeValue = null;
     }
 
     protected function doSetValue($value): void

--- a/src/Eav/Infra/Doctrine/Repository/EntityAttributeValueRepositoryTrait.php
+++ b/src/Eav/Infra/Doctrine/Repository/EntityAttributeValueRepositoryTrait.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use MsgPhp\Domain\Infra\Doctrine\DomainEntityRepositoryTrait;
 use MsgPhp\Eav\AttributeIdInterface;
+use MsgPhp\Eav\Entity\AttributeValue;
 
 /**
  * @author Roland Franssen <franssen.roland@gmail.com>
@@ -19,9 +20,14 @@ trait EntityAttributeValueRepositoryTrait
     private function addAttributeCriteria(QueryBuilder $qb, AttributeIdInterface $attributeId, $value = null): void
     {
         $field = $this->alias.'.'.$this->attributeValueField;
+        $targetClass = $this->em->getClassMetadata($this->class)->getAssociationMapping($this->attributeValueField)['targetEntity'];
+
+        if (!is_subclass_of($targetClass, AttributeValue::class)) {
+            throw new \LogicException(sprintf('The field "%s" is expected to be an association mapping for "%s", got "%s".', $this->class.'.'.$this->attributeValueField, AttributeValue::class, $targetClass));
+        }
 
         if (3 === \func_num_args()) {
-            $qb->join($field, 'attribute_value', Join::WITH, 'attribute_value.checksum = '.$this->addFieldParameter($qb, $this->attributeValueField, md5(serialize($value))));
+            $qb->join($field, 'attribute_value', Join::WITH, 'attribute_value.checksum = '.$this->addFieldParameter($qb, $this->attributeValueField, $targetClass::getChecksum($value)));
         } else {
             $qb->join($field, 'attribute_value');
         }

--- a/src/Eav/Tests/Entity/AttributeValueTest.php
+++ b/src/Eav/Tests/Entity/AttributeValueTest.php
@@ -37,6 +37,14 @@ final class AttributeValueTest extends TestCase
         $this->assertSame($newValue, $attributeValue->getValue());
     }
 
+    public function testGetChecksum(): void
+    {
+        $this->assertSame(AttributeValue::getChecksum('foo'), AttributeValue::getChecksum('foo'));
+        $this->assertSame(AttributeValue::getChecksum(1), AttributeValue::getChecksum(1));
+        $this->assertNotSame(AttributeValue::getChecksum('foo'), AttributeValue::getChecksum('bar'));
+        $this->assertNotSame(AttributeValue::getChecksum(1), AttributeValue::getChecksum('1'));
+    }
+
     public function provideAttributeValues(): iterable
     {
         yield [null, true];

--- a/src/Eav/Tests/Entity/AttributeValueTest.php
+++ b/src/Eav/Tests/Entity/AttributeValueTest.php
@@ -21,7 +21,6 @@ final class AttributeValueTest extends TestCase
         $this->assertSame($attribute, $attributeValue->getAttribute());
         $this->assertSame($attribute->getId(), $attributeValue->getAttributeId());
         $this->assertSame('value', $attributeValue->getValue());
-        $this->assertSame(md5(serialize('value')), $attributeValue->getChecksum());
     }
 
     /**
@@ -30,13 +29,11 @@ final class AttributeValueTest extends TestCase
     public function testChangeValue($initialValue, $newValue): void
     {
         $attributeValue = $this->createEntity($this->createMock(AttributeValueIdInterface::class), $this->createMock(Attribute::class), $initialValue);
-        $checksum = $attributeValue->getChecksum();
 
         $this->assertSame($initialValue, $attributeValue->getValue());
 
         $attributeValue->changeValue($newValue);
 
-        $this->assertNotSame($checksum, $attributeValue->getChecksum());
         $this->assertSame($newValue, $attributeValue->getValue());
     }
 


### PR DESCRIPTION
no need to expose checksums thru public API, instead implementators should be able to customize the checksum generation.
