### PR TITLE
modify cacheWarmer to include files from config dir if they exist

### DIFF
--- a/src/Domain/Infra/DependencyInjection/BundleHelper.php
+++ b/src/Domain/Infra/DependencyInjection/BundleHelper.php
@@ -211,9 +211,9 @@ final class BundleHelper
         if (FeatureDetection::hasFrameworkBundle($container)) {
             $container->register(DoctrineInfra\MappingCacheWarmer::class)
                 ->setPublic(false)
-                ->setArgument('$rootDir', '%kernel.project_dir%')
                 ->setArgument('$dirName', 'msgphp/doctrine-mapping')
                 ->setArgument('$mappingFiles', '%msgphp.doctrine.mapping_files%')
+                ->setArgument('$rootDir', '%kernel.project_dir%/config/packages/msgphp/doctrine')
                 ->addTag('kernel.cache_warmer', ['priority' => 100]);
         }
     }

--- a/src/Domain/Infra/DependencyInjection/BundleHelper.php
+++ b/src/Domain/Infra/DependencyInjection/BundleHelper.php
@@ -211,6 +211,7 @@ final class BundleHelper
         if (FeatureDetection::hasFrameworkBundle($container)) {
             $container->register(DoctrineInfra\MappingCacheWarmer::class)
                 ->setPublic(false)
+                ->setArgument('$rootDir', '%kernel.project_dir%')
                 ->setArgument('$dirName', 'msgphp/doctrine-mapping')
                 ->setArgument('$mappingFiles', '%msgphp.doctrine.mapping_files%')
                 ->addTag('kernel.cache_warmer', ['priority' => 100]);

--- a/src/Domain/Infra/DependencyInjection/BundleHelper.php
+++ b/src/Domain/Infra/DependencyInjection/BundleHelper.php
@@ -213,7 +213,7 @@ final class BundleHelper
                 ->setPublic(false)
                 ->setArgument('$dirName', 'msgphp/doctrine-mapping')
                 ->setArgument('$mappingFiles', '%msgphp.doctrine.mapping_files%')
-                ->setArgument('$rootDir', '%kernel.project_dir%/config/packages/msgphp/doctrine')
+                ->setArgument('$configDir', '%msgphp.doctrine.config_folder%')
                 ->addTag('kernel.cache_warmer', ['priority' => 100]);
         }
     }

--- a/src/Domain/Infra/DependencyInjection/ExtensionHelper.php
+++ b/src/Domain/Infra/DependencyInjection/ExtensionHelper.php
@@ -71,6 +71,7 @@ final class ExtensionHelper
 
         $container->setParameter($param = 'msgphp.doctrine.type_config', $container->hasParameter($param) ? $typeConfig + $container->getParameter($param) : $typeConfig);
         $container->setParameter($param = 'msgphp.doctrine.mapping_files', $container->hasParameter($param) ? array_merge($container->getParameter($param), $mappingFiles) : $mappingFiles);
+        $container->setParameter($param = 'msgphp.doctrine.config_folder', $container->hasParameter($param) ? $container->getParameter($param) : $container->getParameter('kernel.project_dir') . '/config/packages/msgphp/doctrine');
 
         $container->prependExtensionConfig('doctrine', [
             'dbal' => [

--- a/src/Domain/Infra/Doctrine/MappingCacheWarmer.php
+++ b/src/Domain/Infra/Doctrine/MappingCacheWarmer.php
@@ -14,15 +14,15 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
  */
 final class MappingCacheWarmer implements CacheWarmerInterface
 {
-    private $rootDir;
     private $dirName;
     private $mappingFiles;
+    private $rootDir;
 
-    public function __construct(string $rootDir, string $dirName, array $mappingFiles)
+    public function __construct(string $dirName, array $mappingFiles, string $rootDir = null)
     {
-        $this->rootDir = $rootDir;
         $this->dirName = $dirName;
         $this->mappingFiles = $mappingFiles;
+        $this->rootDir = $rootDir;
     }
 
     public function isOptional(): bool
@@ -37,13 +37,11 @@ final class MappingCacheWarmer implements CacheWarmerInterface
 
         foreach ($this->mappingFiles as $file) {
             $filename = basename($file);
-            $split = explode('.', $file);
-            $bundle = strtolower(array_shift($split));
 
-            if ($filesystem->exists($this->rootDir.'/config/packages/msgphp/'.$bundle.'/'.$filename)) {
-                $filesystem->copy($this->rootDir.'/config/packages/msgphp/'.$bundle.'/'.$filename, $target.'/'.basename($file));
+            if ($this->rootDir && $filesystem->exists($this->rootDir.'/'.$filename)) {
+                $filesystem->copy($this->rootDir.'/'.$filename, $target.'/'.basename($file));
             } else {
-                $filesystem->copy($file, $target.'/'.basename($file));
+                $filesystem->copy($file, $target.'/'.$filename);
             }
         }
     }

--- a/src/Domain/Infra/Doctrine/MappingCacheWarmer.php
+++ b/src/Domain/Infra/Doctrine/MappingCacheWarmer.php
@@ -16,13 +16,13 @@ final class MappingCacheWarmer implements CacheWarmerInterface
 {
     private $dirName;
     private $mappingFiles;
-    private $rootDir;
+    private $configDir;
 
-    public function __construct(string $dirName, array $mappingFiles, string $rootDir = null)
+    public function __construct(string $dirName, array $mappingFiles, string $configDir = null)
     {
         $this->dirName = $dirName;
         $this->mappingFiles = $mappingFiles;
-        $this->rootDir = $rootDir;
+        $this->configDir = $configDir;
     }
 
     public function isOptional(): bool
@@ -38,8 +38,8 @@ final class MappingCacheWarmer implements CacheWarmerInterface
         foreach ($this->mappingFiles as $file) {
             $filename = basename($file);
 
-            if ($this->rootDir && $filesystem->exists($this->rootDir.'/'.$filename)) {
-                $filesystem->copy($this->rootDir.'/'.$filename, $target.'/'.basename($file));
+            if ($this->configDir && $filesystem->exists($this->configDir.'/'.$filename)) {
+                $filesystem->copy($this->configDir.'/'.$filename, $target.'/'.basename($file));
             } else {
                 $filesystem->copy($file, $target.'/'.$filename);
             }

--- a/src/Domain/Infra/Doctrine/MappingCacheWarmer.php
+++ b/src/Domain/Infra/Doctrine/MappingCacheWarmer.php
@@ -14,11 +14,13 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
  */
 final class MappingCacheWarmer implements CacheWarmerInterface
 {
+    private $rootDir;
     private $dirName;
     private $mappingFiles;
 
-    public function __construct(string $dirName, array $mappingFiles)
+    public function __construct(string $rootDir, string $dirName, array $mappingFiles)
     {
+        $this->rootDir = $rootDir;
         $this->dirName = $dirName;
         $this->mappingFiles = $mappingFiles;
     }
@@ -34,7 +36,15 @@ final class MappingCacheWarmer implements CacheWarmerInterface
         $filesystem->mkdir($target = $cacheDir.'/'.$this->dirName);
 
         foreach ($this->mappingFiles as $file) {
-            $filesystem->copy($file, $target.'/'.basename($file));
+            $filename = basename($file);
+            $split = explode('.', $file);
+            $bundle = strtolower(array_shift($split));
+
+            if ($filesystem->exists($this->rootDir.'/config/packages/msgphp/'.$bundle.'/'.$filename)) {
+                $filesystem->copy($this->rootDir.'/config/packages/msgphp/'.$bundle.'/'.$filename, $target.'/'.basename($file));
+            } else {
+                $filesystem->copy($file, $target.'/'.basename($file));
+            }
         }
     }
 }


### PR DESCRIPTION
I've modified the CacheWarmer to first check the config folder and only if a file doesn't exist there copy it from the source. This way single files can be overridden, while keeping the default config for others intact.

Possible solution for: https://github.com/msgphp/msgphp/issues/210

Cache Warmer will now check the config dir for the files.

Ex. for the file `vendor/msgphp/user/Infra/Doctrine/Resources/dist-mapping/User.Entity.Credential.Email.orm.xml` it would first check `config/packages/msgphp/user/User.Entity.Credential.Email.orm.xml`

Possible future enhancement: Copy the config files when the `make` command runs.
