### PR TITLE
Resettable feature

### DIFF
--- a/src/Domain/Infra/DependencyInjection/BundleHelper.php
+++ b/src/Domain/Infra/DependencyInjection/BundleHelper.php
@@ -201,7 +201,8 @@ final class BundleHelper
 
         $container->register(DoctrineInfra\ObjectFieldMappings::class)
             ->setPublic(false)
-            ->addTag('msgphp.doctrine.object_field_mappings', ['priority' => -100]);
+            ->addTag('msgphp.doctrine.object_field_mappings', ['priority' => -100])
+            ->setArgument('$keyMaxLength', '%msgphp.doctrine.key_max_length%');
 
         $container->register(DoctrineInfra\Event\ObjectFieldMappingListener::class)
             ->setPublic(false)

--- a/src/Domain/Infra/DependencyInjection/BundleHelper.php
+++ b/src/Domain/Infra/DependencyInjection/BundleHelper.php
@@ -201,8 +201,7 @@ final class BundleHelper
 
         $container->register(DoctrineInfra\ObjectFieldMappings::class)
             ->setPublic(false)
-            ->addTag('msgphp.doctrine.object_field_mappings', ['priority' => -100])
-            ->setArgument('$keyMaxLength', '%msgphp.doctrine.key_max_length%');
+            ->addTag('msgphp.doctrine.object_field_mappings', ['priority' => -100]);
 
         $container->register(DoctrineInfra\Event\ObjectFieldMappingListener::class)
             ->setPublic(false)

--- a/src/Domain/Infra/DependencyInjection/Compiler/DoctrineObjectFieldMappingPass.php
+++ b/src/Domain/Infra/DependencyInjection/Compiler/DoctrineObjectFieldMappingPass.php
@@ -39,7 +39,7 @@ final class DoctrineObjectFieldMappingPass implements CompilerPassInterface
                 throw new InvalidArgumentException(sprintf('Provider "%s" must implement "%s".', $providerId, ObjectFieldMappingsProviderInterface::class));
             }
 
-            foreach ($providerClass::provideObjectFieldMappings() as $class => $mapping) {
+            foreach ($providerClass::provideObjectFieldMappings($container->getParameter('msgphp.doctrine.key_max_length')) as $class => $mapping) {
                 if (isset($mappings[$class])) {
                     continue;
                 }

--- a/src/Domain/Infra/DependencyInjection/ExtensionHelper.php
+++ b/src/Domain/Infra/DependencyInjection/ExtensionHelper.php
@@ -71,6 +71,7 @@ final class ExtensionHelper
 
         $container->setParameter($param = 'msgphp.doctrine.type_config', $container->hasParameter($param) ? $typeConfig + $container->getParameter($param) : $typeConfig);
         $container->setParameter($param = 'msgphp.doctrine.mapping_files', $container->hasParameter($param) ? array_merge($container->getParameter($param), $mappingFiles) : $mappingFiles);
+        $container->setParameter($param = 'msgphp.doctrine.key_max_length', $container->hasParameter($param) ? intval($container->getParameter($param)) : 255);
 
         $container->prependExtensionConfig('doctrine', [
             'dbal' => [

--- a/src/Domain/Infra/Doctrine/ObjectFieldMappings.php
+++ b/src/Domain/Infra/Doctrine/ObjectFieldMappings.php
@@ -13,13 +13,14 @@ use MsgPhp\Domain\Entity\{Features, Fields};
  */
 final class ObjectFieldMappings implements ObjectFieldMappingsProviderInterface
 {
-    public static function provideObjectFieldMappings(): iterable
+    public static function provideObjectFieldMappings(int $keyMaxLength = 255): iterable
     {
         yield Features\CanBeConfirmed::class => [
             'confirmationToken' => [
                 'type' => 'string',
                 'unique' => true,
                 'nullable' => true,
+                'length' => $keyMaxLength,
             ],
             'confirmedAt' => [
                 'type' => 'datetime',

--- a/src/Domain/Infra/Doctrine/ObjectFieldMappingsProviderInterface.php
+++ b/src/Domain/Infra/Doctrine/ObjectFieldMappingsProviderInterface.php
@@ -15,5 +15,5 @@ interface ObjectFieldMappingsProviderInterface
     public const TYPE_ONE_TO_MANY = 'oneToMany';
     public const TYPE_ONE_TO_ONE = 'oneToOne';
 
-    public static function provideObjectFieldMappings(): iterable;
+    public static function provideObjectFieldMappings(int $keyMaxLength = 255): iterable;
 }

--- a/src/Eav/Infra/Doctrine/ObjectFieldMappings.php
+++ b/src/Eav/Infra/Doctrine/ObjectFieldMappings.php
@@ -14,7 +14,7 @@ use MsgPhp\Eav\Entity\{AttributeValue, Features};
  */
 final class ObjectFieldMappings implements ObjectFieldMappingsProviderInterface
 {
-    public static function provideObjectFieldMappings(): iterable
+    public static function provideObjectFieldMappings(int $keyMaxLength = 255): iterable
     {
         yield Features\EntityAttributeValue::class => [
             'attributeValue' => [

--- a/src/User/Infra/Doctrine/ObjectFieldMappings.php
+++ b/src/User/Infra/Doctrine/ObjectFieldMappings.php
@@ -41,6 +41,7 @@ final class ObjectFieldMappings implements ObjectFieldMappingsProviderInterface
                 'type' => 'string',
                 'unique' => true,
                 'nullable' => true,
+                'length' => 191,
             ],
             'passwordRequestedAt' => [
                 'type' => 'datetime',

--- a/src/User/Infra/Doctrine/ObjectFieldMappings.php
+++ b/src/User/Infra/Doctrine/ObjectFieldMappings.php
@@ -24,7 +24,14 @@ final class ObjectFieldMappings implements ObjectFieldMappingsProviderInterface
         Features\TokenCredential::class => Credential\Token::class,
     ];
 
-    public static function provideObjectFieldMappings(): iterable
+    private $keyMaxLength;
+
+    public function __construct(int $keyMaxLength = 255)
+    {
+        $this->keyMaxLength = $keyMaxLength;
+    }
+
+    public static function provideObjectFieldMappings(int $keyMaxLength = 255): iterable
     {
         foreach (self::CREDENTIALS as $object => $credential) {
             yield $object => [
@@ -41,7 +48,7 @@ final class ObjectFieldMappings implements ObjectFieldMappingsProviderInterface
                 'type' => 'string',
                 'unique' => true,
                 'nullable' => true,
-                'length' => 191,
+                'length' => $keyMaxLength,
             ],
             'passwordRequestedAt' => [
                 'type' => 'datetime',


### PR DESCRIPTION
Since not all db/field length definitions are done in `*.orm.xml` files (see https://github.com/msgphp/msgphp/pull/211 and https://github.com/msgphp/msgphp/issues/210), a modification of the `ObjectFieldMappings` class is needed.

I've added a new config value: `msgphp.doctrine.key_max_length` defaulting to 255 and getting padded to the `ObjectFieldMappings::provideObjectFieldMappings()` function as parameter. it then is used to set a length limit for unique/key entries.

AFAIK there's no way to reuse this parameter for the `*.orm.xml` files. We could theoretically modify the `CacheWarmer` class to check the files it's copying for a string like `%msgphp.doctrine.key_max_length%` and if that string exists, replace it with the config value in the cache folder. @ro0NL  what do you think?