### PR TITLE
Turn DomainCollection's filter & slice functions into lazy functions

### DIFF
--- a/src/Domain/DomainCollection.php
+++ b/src/Domain/DomainCollection.php
@@ -121,8 +121,7 @@ final class DomainCollection implements DomainCollectionInterface
     public function filter(callable $filter): DomainCollectionInterface
     {
         if ($this->elements instanceof \Traversable) {
-            return new self((function() use ($filter): iterable
-            {
+            return new self((function () use ($filter): iterable {
                 foreach ($this->elements as $key => $element) {
                     if ($filter($element)) {
                         yield $key => $element;
@@ -137,8 +136,7 @@ final class DomainCollection implements DomainCollectionInterface
     public function slice(int $offset, int $limit = 0): DomainCollectionInterface
     {
         if ($this->elements instanceof \Traversable) {
-            return new self((function() use ($offset, $limit): iterable
-            {
+            return new self((function () use ($offset, $limit): iterable {
                 $i = -1;
                 foreach ($this->elements as $key => $element) {
                     if (++$i < $offset) {

--- a/src/Domain/DomainCollection.php
+++ b/src/Domain/DomainCollection.php
@@ -121,14 +121,14 @@ final class DomainCollection implements DomainCollectionInterface
     public function filter(callable $filter): DomainCollectionInterface
     {
         if ($this->elements instanceof \Traversable) {
-            $elements = [];
-            foreach ($this->elements as $key => $element) {
-                if ($filter($element)) {
-                    $elements[$key] = $element;
+            return new self((function() use ($filter): iterable
+            {
+                foreach ($this->elements as $key => $element) {
+                    if ($filter($element)) {
+                        yield $key => $element;
+                    }
                 }
-            }
-
-            return new self($elements);
+            })());
         }
 
         return new self(array_filter($this->elements, $filter));
@@ -137,21 +137,21 @@ final class DomainCollection implements DomainCollectionInterface
     public function slice(int $offset, int $limit = 0): DomainCollectionInterface
     {
         if ($this->elements instanceof \Traversable) {
-            $elements = [];
-            $i = -1;
-            foreach ($this->elements as $key => $element) {
-                if (++$i < $offset) {
-                    continue;
+            return new self((function() use ($offset, $limit): iterable
+            {
+                $i = -1;
+                foreach ($this->elements as $key => $element) {
+                    if (++$i < $offset) {
+                        continue;
+                    }
+
+                    if ($limit && $i >= ($offset + $limit)) {
+                        break;
+                    }
+
+                    yield $key => $element;
                 }
-
-                if ($limit && $i >= ($offset + $limit)) {
-                    break;
-                }
-
-                $elements[$key] = $element;
-            }
-
-            return new self($elements);
+            })());
         }
 
         return new self(\array_slice($this->elements, $offset, $limit ?: null, true));

--- a/src/Domain/Tests/DomainCollectionTest.php
+++ b/src/Domain/Tests/DomainCollectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MsgPhp\Domain\Tests;
 
+use function iterator_to_array;
 use MsgPhp\Domain\DomainCollection;
 use MsgPhp\Domain\DomainCollectionInterface;
 
@@ -112,9 +113,11 @@ final class DomainCollectionTest extends AbstractDomainCollectionTest
         })));
         self::assertSame([1, null, 3], $visited);
 
-        $this->assertClosedGenerator();
+        $result = static::createLazyCollection([1, 2, 3])->filter($filter);
 
-        $collection->filter($filter);
+        iterator_to_array($result);
+        $this->assertClosedGenerator();
+        iterator_to_array($result);
     }
 
     public function testLazySlice(): void
@@ -124,9 +127,11 @@ final class DomainCollectionTest extends AbstractDomainCollectionTest
         self::assertSame([1 => 2], iterator_to_array(($collection = static::createLazyCollection([1, 2, 3, null, 5], $visited))->slice(1, 1)));
         self::assertSame([1, 2, 3], $visited);
 
-        $this->assertUnrewindableGenerator();
+        $result = static::createLazyCollection([1, 2, 3])->slice(0);
 
-        $collection->slice(0);
+        iterator_to_array($result);
+        $this->assertClosedGenerator();
+        iterator_to_array($result);
     }
 
     public function testLazyMap(): void

--- a/src/Domain/Tests/DomainCollectionTest.php
+++ b/src/Domain/Tests/DomainCollectionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MsgPhp\Domain\Tests;
 
-use function iterator_to_array;
 use MsgPhp\Domain\DomainCollection;
 use MsgPhp\Domain\DomainCollectionInterface;
 
@@ -113,9 +112,8 @@ final class DomainCollectionTest extends AbstractDomainCollectionTest
         })));
         self::assertSame([1, null, 3], $visited);
 
-        $result = static::createLazyCollection([1, 2, 3])->filter($filter);
+        $result = $collection->filter($filter);
 
-        iterator_to_array($result);
         $this->assertClosedGenerator();
         iterator_to_array($result);
     }
@@ -127,10 +125,9 @@ final class DomainCollectionTest extends AbstractDomainCollectionTest
         self::assertSame([1 => 2], iterator_to_array(($collection = static::createLazyCollection([1, 2, 3, null, 5], $visited))->slice(1, 1)));
         self::assertSame([1, 2, 3], $visited);
 
-        $result = static::createLazyCollection([1, 2, 3])->slice(0);
+        $result = $collection->slice(0);
 
-        iterator_to_array($result);
-        $this->assertClosedGenerator();
+        $this->assertUnrewindableGenerator();
         iterator_to_array($result);
     }
 


### PR DESCRIPTION
Avoid loading all the elements in memory when calling these functions.