### PR TITLE
- message bus configuration information update for symfony 4.2+

### DIFF
--- a/docs/cookbook/configuring-a-message-bus.md
+++ b/docs/cookbook/configuring-a-message-bus.md
@@ -41,6 +41,29 @@ framework:
                     - allow_no_handler
 ```
 
+For Symfony 4.2+:
+
+```
+framework:
+    messenger:
+        # ...
+
+        default_bus: command_bus
+        buses:
+            command_bus:
+                middleware:
+                    - msgphp.messenger.console_message_receiver
+            event_bus:
+                default_middleware: allow_no_handlers
+                middleware:
+                    - msgphp.messenger.console_message_receiver
+
+services:
+    msgphp.messenger.command_bus: '@command_bus'
+    msgphp.messenger.event_bus: '@event_bus'
+
+```
+
 By default MsgPHP uses the bus configured under `framework.messenger.default_bus`. You can override its alias services
 to use any other bus:
 

--- a/docs/cookbook/configuring-a-message-bus.md
+++ b/docs/cookbook/configuring-a-message-bus.md
@@ -36,24 +36,6 @@ framework:
                 middleware:
                     - msgphp.messenger.console_message_receiver
             event_bus:
-                middleware:
-                    - msgphp.messenger.console_message_receiver
-                    - allow_no_handler
-```
-
-For Symfony 4.2+:
-
-```
-framework:
-    messenger:
-        # ...
-
-        default_bus: command_bus
-        buses:
-            command_bus:
-                middleware:
-                    - msgphp.messenger.console_message_receiver
-            event_bus:
                 default_middleware: allow_no_handlers
                 middleware:
                     - msgphp.messenger.console_message_receiver

--- a/docs/cookbook/configuring-a-message-bus.md
+++ b/docs/cookbook/configuring-a-message-bus.md
@@ -39,7 +39,6 @@ framework:
                 default_middleware: allow_no_handlers
                 middleware:
                     - msgphp.messenger.console_message_receiver
-
 ```
 
 By default MsgPHP uses the bus configured under `framework.messenger.default_bus`. You can override its alias services

--- a/docs/cookbook/configuring-a-message-bus.md
+++ b/docs/cookbook/configuring-a-message-bus.md
@@ -40,10 +40,6 @@ framework:
                 middleware:
                     - msgphp.messenger.console_message_receiver
 
-services:
-    msgphp.messenger.command_bus: '@command_bus'
-    msgphp.messenger.event_bus: '@event_bus'
-
 ```
 
 By default MsgPHP uses the bus configured under `framework.messenger.default_bus`. You can override its alias services


### PR DESCRIPTION
adds some missing configuration information
