### PR TITLE
Use new message bus alias to avoid deprecation error.

### DIFF
--- a/src/Domain/Infrastructure/DependencyInjection/BundleHelper.php
+++ b/src/Domain/Infrastructure/DependencyInjection/BundleHelper.php
@@ -88,8 +88,8 @@ final class BundleHelper
     private static function initMessageBus(ContainerBuilder $container): void
     {
         if (FeatureDetection::isMessengerAvailable($container)) {
-            $container->setAlias('msgphp.messenger.command_bus', new Alias('message_bus', false));
-            $container->setAlias('msgphp.messenger.event_bus', new Alias('message_bus', false));
+            $container->setAlias('msgphp.messenger.command_bus', new Alias('messenger.default_bus', false));
+            $container->setAlias('msgphp.messenger.event_bus', new Alias('messenger.default_bus', false));
             $container->setAlias('msgphp.command_bus', new Alias('msgphp.messenger.command_bus', false));
             $container->register(MessengerInfrastructure\DomainMessageBus::class)
                 ->setPublic(false)


### PR DESCRIPTION
Fixes this warning: The "message_bus" service is deprecated, use the "messenger.default_bus" service instead. It is being referenced by the "msgphp.messenger.command_bus" alias.

<!--
- Be descriptive
- Bug fix / New feature?
- Anything left to do in in docs/ or src/*/Tests/?
-->
