### PR TITLE
Allow no-interaction option to generate the files

### DIFF
--- a/src/UserBundle/Maker/UserMaker.php
+++ b/src/UserBundle/Maker/UserMaker.php
@@ -157,12 +157,12 @@ final class UserMaker implements MakerInterface
                 } else {
                     $io->writeln($differ->diff($exist ? file_get_contents($file) : '', $contents));
                 }
-            } while ('r' === $choice = $io->choice('Write changes and continue reviewing?', $choices, $choices['r']));
+            } while ( !$input->getOption('no-interaction') || ('r' === $choice = $io->choice('Write changes and continue reviewing?', $choices, $choices['r'])) );
 
-            if ('y' === $choice) {
+            if ( $input->getOption('no-interaction') || ('y' === $choice) ) {
                 $writer($file, $contents);
             }
-        }
+       }
 
         $io->success('Done!');
 


### PR DESCRIPTION
I _think_ this should work, you still need to install the Differ bundle, even though it's not actually essential.  Ideally those file diffs wouldn't be displayed, but $input isn't available in the method that checks for that bundle.

This option has no tests right now.

<!--
- Be descriptive
- Bug fix / New feature?
- Anything left to do in in docs/ or src/*/Tests/?
-->
fixes #352