### PR TITLE
Update Symfony dependencies to allow 5.0 packages

### DIFF
--- a/src/Domain/composer.json
+++ b/src/Domain/composer.json
@@ -31,8 +31,8 @@
     "require-dev": {
         "doctrine/orm": "^2.6",
         "ramsey/uuid": "^3.7",
-        "symfony/messenger": "^4.3",
-        "symfony/var-exporter": "^4.2"
+        "symfony/messenger": "^4.3 || ^5.0",
+        "symfony/var-exporter": "^4.2 || ^5.0"
     },
     "config": {
         "preferred-install": {

--- a/src/Eav/composer.json
+++ b/src/Eav/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.6",
-        "symfony/messenger": "^4.3"
+        "symfony/messenger": "^4.3 || ^5.0"
     },
     "config": {
         "preferred-install": {

--- a/src/EavBundle/composer.json
+++ b/src/EavBundle/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "msgphp/eav": "^0.14",
-        "symfony/config": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
-        "symfony/http-kernel": "^3.4 || ^4.2"
+        "symfony/config": "^3.4 || ^4.2 || ^5.0",
+        "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.2 || ^5.0"
     },
     "config": {
         "preferred-install": {

--- a/src/User/Infrastructure/Form/Type/HashedPasswordType.php
+++ b/src/User/Infrastructure/Form/Type/HashedPasswordType.php
@@ -96,7 +96,6 @@ final class HashedPasswordType extends AbstractType
                     $context->buildViolation($passwordConfirmOptions['invalid_message'], $passwordConfirmOptions['invalid_message_parameters'])
                         ->setCause($this)
                         ->setInvalidValue($value)
-                        ->setTranslationDomain($passwordConfirmOptions['translation_domain'])
                         ->addViolation()
                     ;
                 }

--- a/src/User/Tests/Infrastructure/Form/Type/HashedPasswordTypeTest.php
+++ b/src/User/Tests/Infrastructure/Form/Type/HashedPasswordTypeTest.php
@@ -165,14 +165,19 @@ final class HashedPasswordTypeTest extends TypeTestCase
     protected function getExtensions(): array
     {
         $hashing = new class() implements PasswordEncoderInterface {
-            public function encodePassword($raw, $salt)
+            public function encodePassword(string $raw, ?string $salt): string
             {
                 return (string) json_encode([$raw, $salt]);
             }
 
-            public function isPasswordValid($encoded, $raw, $salt)
+            public function isPasswordValid(string $encoded, string $raw, ?string $salt): bool
             {
                 return $encoded === $this->encodePassword($raw, $salt);
+            }
+
+            public function needsRehash(string $encoded): bool
+            {
+                return false;
             }
         };
 

--- a/src/User/Tests/Infrastructure/Form/Type/HashedPasswordTypeTest.php
+++ b/src/User/Tests/Infrastructure/Form/Type/HashedPasswordTypeTest.php
@@ -165,12 +165,12 @@ final class HashedPasswordTypeTest extends TypeTestCase
     protected function getExtensions(): array
     {
         $hashing = new class() implements PasswordEncoderInterface {
-            public function encodePassword(string $raw, ?string $salt): string
+            public function encodePassword($raw, $salt)
             {
                 return (string) json_encode([$raw, $salt]);
             }
 
-            public function isPasswordValid(string $encoded, string $raw, ?string $salt): bool
+            public function isPasswordValid($encoded, $raw, $salt)
             {
                 return $encoded === $this->encodePassword($raw, $salt);
             }

--- a/src/User/composer.json
+++ b/src/User/composer.json
@@ -21,10 +21,10 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.6",
-        "symfony/form": "^3.4.24 || ^4.2.5",
-        "symfony/messenger": "^4.3",
-        "symfony/security-core": "^3.4 || ^4.2",
-        "symfony/validator": "^3.4 || ^4.2"
+        "symfony/form": "^3.4.24 || ^4.2.5 || ^5.0",
+        "symfony/messenger": "^4.3 || ^5.0",
+        "symfony/security-core": "^3.4 || ^4.2 || ^5.0",
+        "symfony/validator": "^3.4 || ^4.2 || ^5.0"
     },
     "config": {
         "preferred-install": {

--- a/src/UserBundle/composer.json
+++ b/src/UserBundle/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "msgphp/user": "^0.14",
-        "symfony/config": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
-        "symfony/http-kernel": "^3.4 || ^4.2"
+        "symfony/config": "^3.4 || ^4.2 || ^5.0",
+        "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.2 || ^5.0"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
Allow ^5.0 versions of the Symfony components so the user bundle can be require'd in Symfony 5 projects.